### PR TITLE
Add support for Moondrop Moonriver 2 Ti

### DIFF
--- a/app/src/main/kotlin/io/github/tommygeenexus/usbdonglecontrol/dongle/SupportedDongles.kt
+++ b/app/src/main/kotlin/io/github/tommygeenexus/usbdonglecontrol/dongle/SupportedDongles.kt
@@ -25,12 +25,14 @@ import io.github.tommygeenexus.usbdonglecontrol.dongle.fiio.ka.ka5.FiioKa5
 import io.github.tommygeenexus.usbdonglecontrol.dongle.moondrop.dawn.dawn3544Pro.MoondropDawn35
 import io.github.tommygeenexus.usbdonglecontrol.dongle.moondrop.dawn.dawn3544Pro.MoondropDawn44
 import io.github.tommygeenexus.usbdonglecontrol.dongle.moondrop.dawn.dawn3544Pro.MoondropDawnPro
+import io.github.tommygeenexus.usbdonglecontrol.dongle.moondrop.dawn.dawn3544Pro.MoondropMoonriver2Ti
 
 val supportedDongles = listOf<UsbDongle>(
     FiioKa5(),
     MoondropDawn35(),
     MoondropDawn44(),
-    MoondropDawnPro()
+    MoondropDawnPro(),
+    MoondropMoonriver2Ti()
 )
 
 fun UsbDevice?.toUsbDongleOrNull() = supportedDongles.find { usbDongle ->

--- a/app/src/main/kotlin/io/github/tommygeenexus/usbdonglecontrol/dongle/moondrop/dawn/dawn3544Pro/MoondropMoonriver2Ti.kt
+++ b/app/src/main/kotlin/io/github/tommygeenexus/usbdonglecontrol/dongle/moondrop/dawn/dawn3544Pro/MoondropMoonriver2Ti.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024, Tom Geiselmann (tomgapplicationsdevelopment@gmail.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY,WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.tommygeenexus.usbdonglecontrol.dongle.moondrop.dawn.dawn3544Pro
+
+import io.github.tommygeenexus.usbdonglecontrol.dongle.fiio.ka.ka5.feature.Filter
+import io.github.tommygeenexus.usbdonglecontrol.dongle.fiio.ka.ka5.feature.Gain
+import io.github.tommygeenexus.usbdonglecontrol.dongle.moondrop.dawn.dawn3544Pro.feature.IndicatorState
+import io.github.tommygeenexus.usbdonglecontrol.dongle.moondrop.dawn.dawn3544Pro.feature.VolumeLevel
+import io.github.tommygeenexus.usbdonglecontrol.dongle.moondrop.dawn.dawn3544Pro.feature.default
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class MoondropMoonriver2Ti(
+    override val filter: Filter = Filter.default(),
+    override val gain: Gain = Gain.default(),
+    override val indicatorState: IndicatorState = IndicatorState.default(),
+    override val volumeLevel: VolumeLevel = VolumeLevel.default()
+) : MoondropDawn(
+    modelName = "Moonriver 2 Ti",
+    productId = PRODUCT_ID,
+    filter = filter,
+    gain = gain,
+    indicatorState = indicatorState,
+    volumeLevel = volumeLevel
+) {
+
+    companion object {
+
+        const val PRODUCT_ID = 61547
+    }
+}

--- a/app/src/main/kotlin/io/github/tommygeenexus/usbdonglecontrol/dongle/moondrop/dawn/dawn3544Pro/data/MoondropDawnUsbRepository.kt
+++ b/app/src/main/kotlin/io/github/tommygeenexus/usbdonglecontrol/dongle/moondrop/dawn/dawn3544Pro/data/MoondropDawnUsbRepository.kt
@@ -30,6 +30,7 @@ import io.github.tommygeenexus.usbdonglecontrol.dongle.moondrop.dawn.dawn3544Pro
 import io.github.tommygeenexus.usbdonglecontrol.dongle.moondrop.dawn.dawn3544Pro.MoondropDawn35
 import io.github.tommygeenexus.usbdonglecontrol.dongle.moondrop.dawn.dawn3544Pro.MoondropDawn44
 import io.github.tommygeenexus.usbdonglecontrol.dongle.moondrop.dawn.dawn3544Pro.MoondropDawnPro
+import io.github.tommygeenexus.usbdonglecontrol.dongle.moondrop.dawn.dawn3544Pro.MoondropMoonriver2Ti
 import io.github.tommygeenexus.usbdonglecontrol.dongle.moondrop.dawn.dawn3544Pro.feature.IndicatorState
 import io.github.tommygeenexus.usbdonglecontrol.dongle.moondrop.dawn.dawn3544Pro.feature.VolumeLevel
 import io.github.tommygeenexus.usbdonglecontrol.dongle.moondrop.dawn.dawn3544Pro.feature.createFromPayload
@@ -130,6 +131,16 @@ class MoondropDawnUsbRepository @Inject constructor(
                             )
                         )
                     }
+                    is MoondropMoonriver2Ti -> {
+                        Result.success(
+                            value = usbDongle.copy(
+                                filter = filter,
+                                gain = gain,
+                                indicatorState = indicatorState,
+                                volumeLevel = volumeLevel
+                            )
+                        )
+                    }
                 }
             }.getOrElse { exception ->
                 Timber.e(exception)
@@ -168,6 +179,9 @@ class MoondropDawnUsbRepository @Inject constructor(
                     is MoondropDawnPro -> {
                         Result.success(value = moondropDawn.copy(filter = filter))
                     }
+                    is MoondropMoonriver2Ti -> {
+                        Result.success(value = moondropDawn.copy(filter = filter))
+                    }
                 }
             }.getOrElse { exception ->
                 Timber.e(exception)
@@ -204,6 +218,9 @@ class MoondropDawnUsbRepository @Inject constructor(
                         Result.success(value = moondropDawn.copy(gain = gain))
                     }
                     is MoondropDawnPro -> {
+                        Result.success(value = moondropDawn.copy(gain = gain))
+                    }
+                    is MoondropMoonriver2Ti -> {
                         Result.success(value = moondropDawn.copy(gain = gain))
                     }
                 }
@@ -247,6 +264,9 @@ class MoondropDawnUsbRepository @Inject constructor(
                     is MoondropDawnPro -> {
                         Result.success(value = moondropDawn.copy(indicatorState = indicatorState))
                     }
+                    is MoondropMoonriver2Ti -> {
+                        Result.success(value = moondropDawn.copy(indicatorState = indicatorState))
+                    }
                 }
             }.getOrElse { exception ->
                 Timber.e(exception)
@@ -286,6 +306,9 @@ class MoondropDawnUsbRepository @Inject constructor(
                         Result.success(value = moondropDawn.copy(volumeLevel = volumeLevel))
                     }
                     is MoondropDawnPro -> {
+                        Result.success(value = moondropDawn.copy(volumeLevel = volumeLevel))
+                    }
+                    is MoondropMoonriver2Ti -> {
                         Result.success(value = moondropDawn.copy(volumeLevel = volumeLevel))
                     }
                 }
@@ -371,6 +394,16 @@ class MoondropDawnUsbRepository @Inject constructor(
                         )
                     }
                     is MoondropDawnPro -> {
+                        Result.success(
+                            value = moondropDawn.copy(
+                                filter = filter,
+                                gain = gain,
+                                indicatorState = indicatorState,
+                                volumeLevel = volumeLevel
+                            )
+                        )
+                    }
+                    is MoondropMoonriver2Ti -> {
                         Result.success(
                             value = moondropDawn.copy(
                                 filter = filter,


### PR DESCRIPTION
As the title says
Tho probably a refactor is needed as of now Mooonriver2 Ti uses the Dawn classes and everything else, as it shares every feature with the Dawn class even tho it is not a Dawn dac.

Edit: typo